### PR TITLE
Fixed Build Error [Test]

### DIFF
--- a/src/test/scriptnum_tests.cpp
+++ b/src/test/scriptnum_tests.cpp
@@ -10,7 +10,7 @@
 BOOST_AUTO_TEST_SUITE(scriptnum_tests)
 
 static const long values[] = \
-{ 0, 1, CHAR_MIN, CHAR_MAX, UCHAR_MAX, SHRT_MIN, USHRT_MAX, INT_MIN, INT_MAX, static_cast<long>UINT_MAX, LONG_MIN, LONG_MAX };
+{ 0, 1, CHAR_MIN, CHAR_MAX, UCHAR_MAX, SHRT_MIN, USHRT_MAX, INT_MIN, INT_MAX, static_cast<uint64_t>UINT_MAX, LONG_MIN, LONG_MAX };
 static const long offsets[] = { 1, 0x79, 0x80, 0x81, 0xFF, 0x7FFF, 0x8000, 0xFFFF, 0x10000};
 
 static bool verify(const CBigNum& bignum, const CScriptNum& scriptnum)


### PR DESCRIPTION
As mentioned in private already, you have to cast the UINT_MAX to a uint. While a long might've worked for you, that's actually just luck. To improve memory usage and return to best-practices I would recommend to use a uint64_t instead of a long. 
Again, I already proposed that in private, but somehow a long got added.
With this PR the issue will be fixed.